### PR TITLE
Fix typo in eu-central-1 region name in schema definition

### DIFF
--- a/reportdefinition/aws-cur-reportdefinition.json
+++ b/reportdefinition/aws-cur-reportdefinition.json
@@ -75,7 +75,7 @@
         "ap-northeast-2",
         "ap-northeast-3",
         "ca-central-1",
-        "eu-centrail-1",
+        "eu-central-1",
         "eu-west-1",
         "eu-west-2",
         "eu-west-3",


### PR DESCRIPTION
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
