### PR TITLE
Update resource provider to work in all regions within supported partitions

### DIFF
--- a/reportdefinition/src/main/java/software/amazon/cur/reportdefinition/CreateHandler.java
+++ b/reportdefinition/src/main/java/software/amazon/cur/reportdefinition/CreateHandler.java
@@ -12,14 +12,6 @@ import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 
 public class CreateHandler extends CurBaseHandler {
 
-    public CreateHandler() {
-        super();
-    }
-
-    public CreateHandler(CostAndUsageReportClient client) {
-        super(client);
-    }
-
     @Override
     public ProgressEvent<ResourceModel, CallbackContext> handleRequest(
         final AmazonWebServicesClientProxy proxy,
@@ -29,6 +21,7 @@ public class CreateHandler extends CurBaseHandler {
 
         final ResourceModel model = request.getDesiredResourceState();
         final ReportDefinition reportDefinition = Translator.toReportDefinition(model);
+        final CostAndUsageReportClient curClient = getClient(request);
 
         try {
             proxy.injectCredentialsAndInvokeV2(

--- a/reportdefinition/src/main/java/software/amazon/cur/reportdefinition/DeleteHandler.java
+++ b/reportdefinition/src/main/java/software/amazon/cur/reportdefinition/DeleteHandler.java
@@ -11,14 +11,6 @@ import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 
 public class DeleteHandler extends CurBaseHandler {
 
-    public DeleteHandler() {
-        super();
-    }
-
-    public DeleteHandler(CostAndUsageReportClient client) {
-        super(client);
-    }
-
     @Override
     public ProgressEvent<ResourceModel, CallbackContext> handleRequest(
         final AmazonWebServicesClientProxy proxy,
@@ -27,9 +19,10 @@ public class DeleteHandler extends CurBaseHandler {
         final Logger logger) {
 
         final ResourceModel model = request.getDesiredResourceState();
+        final CostAndUsageReportClient curClient = getClient(request);
 
         // This will throw the exception needed if the report doesn't exist - we don't need the ReportDefinition it returns
-        getReport(model.getReportName(), proxy, logger);
+        getReport(model.getReportName(), proxy, logger, curClient);
 
         try {
             proxy.injectCredentialsAndInvokeV2(

--- a/reportdefinition/src/main/java/software/amazon/cur/reportdefinition/ListHandler.java
+++ b/reportdefinition/src/main/java/software/amazon/cur/reportdefinition/ListHandler.java
@@ -15,20 +15,14 @@ import java.util.stream.Collectors;
 // https://docs.aws.amazon.com/cloudformation-cli/latest/userguide/resource-type-test-contract.html#resource-type-test-contract-list
 public class ListHandler extends CurBaseHandler {
 
-    public ListHandler() {
-        super();
-    }
-
-    public ListHandler(CostAndUsageReportClient client) {
-        super(client);
-    }
-
     @Override
     public ProgressEvent<ResourceModel, CallbackContext> handleRequest(
         final AmazonWebServicesClientProxy proxy,
         final ResourceHandlerRequest<ResourceModel> request,
         final CallbackContext callbackContext,
         final Logger logger) {
+
+        final CostAndUsageReportClient curClient = getClient(request);
 
         try {
             DescribeReportDefinitionsResponse response = proxy.injectCredentialsAndInvokeV2(

--- a/reportdefinition/src/main/java/software/amazon/cur/reportdefinition/ReadHandler.java
+++ b/reportdefinition/src/main/java/software/amazon/cur/reportdefinition/ReadHandler.java
@@ -12,13 +12,6 @@ import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 // https://docs.aws.amazon.com/cloudformation-cli/latest/userguide/resource-type-test-contract.html#resource-type-test-contract-read
 public class ReadHandler extends CurBaseHandler {
 
-    public ReadHandler() {
-        super();
-    }
-
-    public ReadHandler(CostAndUsageReportClient client) {
-        super(client);
-    }
     @Override
     public ProgressEvent<ResourceModel, CallbackContext> handleRequest(
         final AmazonWebServicesClientProxy proxy,
@@ -26,10 +19,11 @@ public class ReadHandler extends CurBaseHandler {
         final CallbackContext callbackContext,
         final Logger logger) {
 
-        String reportName = request.getDesiredResourceState().getReportName();
+        final String reportName = request.getDesiredResourceState().getReportName();
+        final CostAndUsageReportClient curClient = getClient(request);
 
         try {
-            ReportDefinition reportDefinition = getReport(reportName, proxy, logger);
+            ReportDefinition reportDefinition = getReport(reportName, proxy, logger, curClient);
 
             return ProgressEvent.<ResourceModel, CallbackContext>builder()
                 .resourceModel(Translator.toResourceModel(reportDefinition))

--- a/reportdefinition/src/main/java/software/amazon/cur/reportdefinition/UpdateHandler.java
+++ b/reportdefinition/src/main/java/software/amazon/cur/reportdefinition/UpdateHandler.java
@@ -12,23 +12,16 @@ import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 
 public class UpdateHandler extends CurBaseHandler {
 
-    public UpdateHandler() {
-        super();
-    }
-
-    public UpdateHandler(CostAndUsageReportClient client) {
-        super(client);
-    }
-
     @Override
     public ProgressEvent<ResourceModel, CallbackContext> handleRequest(final AmazonWebServicesClientProxy proxy,
             final ResourceHandlerRequest<ResourceModel> request, final CallbackContext callbackContext,
             final Logger logger) {
 
         final ResourceModel model = request.getDesiredResourceState();
+        final CostAndUsageReportClient curClient = getClient(request);
 
         // This will throw the exception needed if the report doesn't exist - we don't need the ReportDefinition it returns
-        getReport(model.getReportName(), proxy, logger);
+        getReport(model.getReportName(), proxy, logger, curClient);
         final ReportDefinition updatedReportDefinition = Translator.toReportDefinition(model);
 
         try {

--- a/reportdefinition/src/test/java/software/amazon/cur/reportdefinition/CreateHandlerTest.java
+++ b/reportdefinition/src/test/java/software/amazon/cur/reportdefinition/CreateHandlerTest.java
@@ -32,9 +32,10 @@ public class CreateHandlerTest {
 
     @Test
     void handleRequest_SimpleSuccess() {
-        final CreateHandler handler = new CreateHandler(TestUtil.TEST_CLIENT);
+        final CreateHandler handler = new CreateHandler();
 
         final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
+            .region(TestUtil.TEST_STACK_REGION)
             .desiredResourceState(TestUtil.TEST_RESOURCE_MODEL)
             .build();
 
@@ -58,9 +59,10 @@ public class CreateHandlerTest {
 
     @Test
     void handleRequest_DuplicateReportName() {
-        final CreateHandler handler = new CreateHandler(TestUtil.TEST_CLIENT);
+        final CreateHandler handler = new CreateHandler();
 
         final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
+            .region(TestUtil.TEST_STACK_REGION)
             .desiredResourceState(TestUtil.TEST_RESOURCE_MODEL)
             .build();
 
@@ -72,9 +74,10 @@ public class CreateHandlerTest {
 
     @Test
     void handleRequest_ReportLimitReached() {
-        final CreateHandler handler = new CreateHandler(TestUtil.TEST_CLIENT);
+        final CreateHandler handler = new CreateHandler();
 
         final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
+            .region(TestUtil.TEST_STACK_REGION)
             .desiredResourceState(TestUtil.TEST_RESOURCE_MODEL)
             .build();
 

--- a/reportdefinition/src/test/java/software/amazon/cur/reportdefinition/DeleteHandlerTest.java
+++ b/reportdefinition/src/test/java/software/amazon/cur/reportdefinition/DeleteHandlerTest.java
@@ -33,7 +33,7 @@ public class DeleteHandlerTest {
 
     @Test
     void handleRequest_SimpleSuccess() {
-        final DeleteHandler handler = new DeleteHandler(TestUtil.TEST_CLIENT);
+        final DeleteHandler handler = new DeleteHandler();
 
         // The input to a delete handler MUST contain either the primaryIdentifier or an additionalIdentifier. Any other properties MAY NOT be included in the request.
         // https://docs.aws.amazon.com/cloudformation-cli/latest/userguide/resource-type-test-contract.html#resource-type-test-contract-delete
@@ -42,7 +42,9 @@ public class DeleteHandlerTest {
             .build();
 
         final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
-                .desiredResourceState(model).build();
+            .region(TestUtil.TEST_STACK_REGION)
+            .desiredResourceState(model)
+            .build();
 
         doReturn(DescribeReportDefinitionsResponse.builder().reportDefinitions(TestUtil.TEST_REPORT_DEFINITION).build())
             .when(proxy)
@@ -67,14 +69,16 @@ public class DeleteHandlerTest {
 
     @Test
     void handleRequest_DoesNotExist() {
-        final DeleteHandler handler = new DeleteHandler(TestUtil.TEST_CLIENT);
+        final DeleteHandler handler = new DeleteHandler();
 
         final ResourceModel model = ResourceModel.builder()
             .reportName(TestUtil.TEST_REPORT_NAME)
             .build();
 
         final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
-                .desiredResourceState(model).build();
+            .region(TestUtil.TEST_STACK_REGION)
+            .desiredResourceState(model)
+            .build();
 
         doReturn(DescribeReportDefinitionsResponse.builder().reportDefinitions(Collections.emptyList()).build())
                 .when(proxy).injectCredentialsAndInvokeV2(any(DescribeReportDefinitionsRequest.class), any());

--- a/reportdefinition/src/test/java/software/amazon/cur/reportdefinition/ListHandlerTest.java
+++ b/reportdefinition/src/test/java/software/amazon/cur/reportdefinition/ListHandlerTest.java
@@ -28,9 +28,10 @@ public class ListHandlerTest {
 
     @Test
     void handleRequest_SimpleSuccess() {
-        final ListHandler handler = new ListHandler(TestUtil.TEST_CLIENT);
+        final ListHandler handler = new ListHandler();
 
         final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
+            .region(TestUtil.TEST_STACK_REGION)
             .build();
 
         doReturn(DescribeReportDefinitionsResponse.builder().reportDefinitions(TestUtil.TEST_REPORT_DEFINITION).build())

--- a/reportdefinition/src/test/java/software/amazon/cur/reportdefinition/ReadHandlerTest.java
+++ b/reportdefinition/src/test/java/software/amazon/cur/reportdefinition/ReadHandlerTest.java
@@ -30,11 +30,12 @@ public class ReadHandlerTest {
 
     @Test
     void handleRequest_SimpleSuccess() {
-        final ReadHandler handler = new ReadHandler(TestUtil.TEST_CLIENT);
+        final ReadHandler handler = new ReadHandler();
 
         // The input to a read handler MUST contain either the primaryIdentifier or an additionalIdentifier. Any other properties MAY NOT be included in the request.
         // https://docs.aws.amazon.com/cloudformation-cli/latest/userguide/resource-type-test-contract.html#resource-type-test-contract-read
         final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
+            .region(TestUtil.TEST_STACK_REGION)
             .desiredResourceState(ResourceModel.builder()
                 .reportName(TestUtil.TEST_REPORT_NAME)
                 .build()
@@ -59,13 +60,14 @@ public class ReadHandlerTest {
 
     @Test
     void handleRequest_DoesNotExist() {
-        final ReadHandler handler = new ReadHandler(TestUtil.TEST_CLIENT);
+        final ReadHandler handler = new ReadHandler();
 
         final ResourceModel model = ResourceModel.builder()
             .reportName(TestUtil.TEST_REPORT_NAME)
             .build();
 
         final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
+            .region(TestUtil.TEST_STACK_REGION)
             .desiredResourceState(model)
             .build();
 

--- a/reportdefinition/src/test/java/software/amazon/cur/reportdefinition/TestUtil.java
+++ b/reportdefinition/src/test/java/software/amazon/cur/reportdefinition/TestUtil.java
@@ -14,6 +14,8 @@ public class TestUtil {
     public static final String TEST_S3_BUCKET = "test-s3-bucket";
     public static final String TEST_S3_PREFIX = "test-s3-prefix";
     public static final String TEST_S3_REGION = "us-east-1";
+    // Use a region other than the service region to test endpoint translation
+    public static final String TEST_STACK_REGION = "us-west-2";
 
     public static final ReportDefinition TEST_REPORT_DEFINITION = ReportDefinition.builder()
         .reportName(TEST_REPORT_NAME)
@@ -43,6 +45,4 @@ public class TestUtil {
         .reportVersioning(ReportVersioning.CREATE_NEW_REPORT.toString())
         .timeUnit(TimeUnit.HOURLY.toString())
         .build();
-
-    public static final CostAndUsageReportClient TEST_CLIENT = CostAndUsageReportClient.builder().build();
 }

--- a/reportdefinition/src/test/java/software/amazon/cur/reportdefinition/UpdateHandlerTest.java
+++ b/reportdefinition/src/test/java/software/amazon/cur/reportdefinition/UpdateHandlerTest.java
@@ -37,7 +37,7 @@ public class UpdateHandlerTest {
 
     @Test
     void handleRequest_SimpleSuccess() {
-        final UpdateHandler handler = new UpdateHandler(TestUtil.TEST_CLIENT);
+        final UpdateHandler handler = new UpdateHandler();
 
         final ResourceModel model = ResourceModel.builder()
             .reportName(TestUtil.TEST_REPORT_NAME)
@@ -54,6 +54,7 @@ public class UpdateHandlerTest {
             .build();
 
         final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
+            .region(TestUtil.TEST_STACK_REGION)
             .desiredResourceState(model)
             .build();
 
@@ -85,12 +86,14 @@ public class UpdateHandlerTest {
 
     @Test
     void handleRequest_DoesNotExist() {
-        final UpdateHandler handler = new UpdateHandler(TestUtil.TEST_CLIENT);
+        final UpdateHandler handler = new UpdateHandler();
 
         final ResourceModel model = ResourceModel.builder().reportName("testReportName").build();
 
         final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
-                .desiredResourceState(model).build();
+            .region(TestUtil.TEST_STACK_REGION)
+            .desiredResourceState(model)
+            .build();
 
         doReturn(DescribeReportDefinitionsResponse.builder().reportDefinitions(Collections.emptyList()).build())
                 .when(proxy)


### PR DESCRIPTION
*Description of changes:*
There is only one instance of the Cost and Usage Report API service per partition. This change is to allow using the `AWS::CUR::ReportDefinition` resource provider in regions other than those where backing service runs. Tested by deploying the resource using `cfn-submit` in us-west-2 and cn-north-1 (for the us-east-1 and cn-northwest-1 backing services respectively) and observing that contract tests passed.

Inspired by https://github.com/aws-cloudformation/aws-cloudformation-resource-providers-cost-explorer/pull/13

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
